### PR TITLE
Sanitize metric names to avoid API errors

### DIFF
--- a/lib/librato/metrics/taps/publisher.rb
+++ b/lib/librato/metrics/taps/publisher.rb
@@ -10,6 +10,10 @@ module Librato
           @user = nil
           @passwd = nil
 
+          def sanitize_metric_name(metric_name)
+            metric_name.gsub(/([^A-Za-z0-9.:\-_]|[\\[\\]]|\\s)/, "")
+          end
+
           def url=(new_url)
             if new_url =~ /^http/
               @url = new_url
@@ -65,14 +69,14 @@ module Librato
             if counters.length > 0
               params[:counters] = {}
               counters.each_pair do |k, v|
-                k = pfx + k
+                k = pfx + sanitize_metric_name(k)
                 params[:counters][k] = {:value => v}
               end
             end
             if gauges.length > 0
               params[:gauges] = {}
               gauges.each_pair do |k, v|
-                k = pfx + k
+                k = pfx + sanitize_metric_name(k)
                 if v.respond_to?(:keys)
                   params[:gauges][k] = v
                 else

--- a/test/test-publisher.rb
+++ b/test/test-publisher.rb
@@ -1,0 +1,26 @@
+require 'test/unit'
+require File.join(File.dirname(__FILE__), '../lib/librato/metrics/taps')
+include Librato::Metrics
+
+class TestPublisher < Test::Unit::TestCase
+
+  def test_metric_name_with_space_is_sanitized
+    metric_name_with_space = "java.lang:type:MemoryPool:CMS Perm Gen"
+    sanitized_metric_name = Taps::Publisher.sanitize_metric_name(metric_name_with_space)
+    assert_equal("java.lang:type:MemoryPool:CMSPermGen", sanitized_metric_name)
+  end
+
+  def test_metric_name_with_quote_is_sanitized
+    metric_name_with_space = "Catalina:type:GlobalRequestProcessor_name:\"ajp-bio-8009\"::bytesReceived"
+    sanitized_metric_name = Taps::Publisher.sanitize_metric_name(metric_name_with_space)
+    assert_equal("Catalina:type:GlobalRequestProcessor_name:ajp-bio-8009::bytesReceived", sanitized_metric_name)
+  end
+
+  def test_regular_metric_name_remains_untouched
+    metric_name_with_space = "java.lang:type:Memory::HeapMemoryUsage.committed"
+    sanitized_metric_name = Taps::Publisher.sanitize_metric_name(metric_name_with_space)
+    assert_equal("java.lang:type:Memory::HeapMemoryUsage.committed", sanitized_metric_name)
+  end
+
+
+end


### PR DESCRIPTION
Hi
I encountered API errors when exporting mbeans containing spaces or other non-alphanumeric characters, so I added a method to clean up metric names, based on a regexp copied from https://github.com/librato/librato-java/blob/master/src/main/java/com/librato/metrics/APIUtil.java 
Check test/test-publisher.rb for metric names examples
Feel free to improve it :)
