### PR TITLE
Updated Cassandra JMX taps files for version 1.2.x.

### DIFF
--- a/examples/cassandra/cfstats-1_2_5.yaml
+++ b/examples/cassandra/cfstats-1_2_5.yaml
@@ -1,0 +1,30 @@
+# Set of attributes to grab for each CF.
+# TODO: Add comment description for each
+#
+---
+BloomFilterDiskSpaceUsed: counter
+BloomFilterFalsePositives: counter
+BloomFilterFalseRatio:
+CompressionRatio:
+DroppableTombstoneRatio:
+LiveDiskSpaceUsed:
+LiveSSTableCount:
+MaxRowSize:
+MeanRowSize:
+MinRowSize:
+MaximumCompactionThreshold:
+MinimumCompactionThreshold:
+MemtableColumnsCount: counter
+MemtableDataSize:
+MemtableSwitchCount: counter
+PendingTasks:
+ReadCount: counter
+RecentBloomFilterFalsePositives:
+RecentBloomFilterFalseRatio:
+RecentReadLatencyMicros:
+RecentWriteLatencyMicros:
+TotalDiskSpaceUsed: counter
+TotalReadLatencyMicros: counter
+TotalWriteLatencyMicros: counter
+UnleveledSSTables:
+WriteCount: counter

--- a/examples/cassandra/tpstats-1_2_5.yaml
+++ b/examples/cassandra/tpstats-1_2_5.yaml
@@ -1,0 +1,146 @@
+# Set of non-CF specific Cassandra JMX knobs
+#
+--- 
+org.apache.cassandra.db:type=BatchlogManager:
+  TotalBatchesReplayed: counter
+org.apache.cassandra.db:type=Caches:
+  KeyCacheCapacityInBytes:
+  KeyCacheEntries:
+  KeyCacheHits: counter
+  KeyCacheRecentHitRate:
+  KeyCacheRequests: counter
+  KeyCacheSize:
+  RowCacheCapacityInBytes:
+  RowCacheEntries:
+  RowCacheHits: counter
+  RowCacheRecentHitRate:
+  RowCacheRequests:
+  RowCacheSize:
+org.apache.cassandra.db:type=Commitlog: 
+  ActiveCount:
+  CompletedTasks: counter
+  PendingTasks:
+  TotalCommitlogSize:
+org.apache.cassandra.db:type=CompactionManager: 
+  CompletedTasks: counter
+  PendingTasks:
+  TotalBytesCompacted: counter
+  TotalCompactionsCompleted: counter
+org.apache.cassandra.db:type=StorageProxy:
+  HintsInProgress:
+  RecentRangeLatencyMicros:
+  RecentReadLatencyMicros:
+  RecentWriteLatencyMicros:
+  TotalRangeLatencyMicros: counter
+  TotalReadLatencyMicros: counter
+  TotalWriteLatencyMicros: counter
+  TotalHints: counter
+  RangeOperations: counter
+  ReadOperations: counter
+  WriteOperations: counter
+org.apache.cassandra.db:type=StorageService: 
+  Load:
+  CompactionThroughputMbPerSec:
+  ExceptionCount: counter
+  StreamThroughputMbPerSec:
+org.apache.cassandra.internal:type=AntiEntropyStage: 
+  ActiveCount:
+  CompletedTasks: counter
+  PendingTasks:
+  CurrentlyBlockedTasks:
+  TotalBlockedTasks: counter
+org.apache.cassandra.internal:type=FlushWriter: 
+  ActiveCount:
+  CompletedTasks: counter
+  PendingTasks:
+  CurrentlyBlockedTasks:
+  TotalBlockedTasks: counter
+org.apache.cassandra.internal:type=GossipStage: 
+  ActiveCount:
+  CompletedTasks: counter
+  PendingTasks:
+  CurrentlyBlockedTasks:
+  TotalBlockedTasks: counter
+org.apache.cassandra.internal:type=HintedHandoff: 
+  ActiveCount:
+  CompletedTasks: counter
+  PendingTasks:
+  CurrentlyBlockedTasks:
+  TotalBlockedTasks: counter
+org.apache.cassandra.internal:type=InternalResponseStage: 
+  ActiveCount:
+  CompletedTasks: counter
+  PendingTasks:
+  CurrentlyBlockedTasks:
+  TotalBlockedTasks: counter
+org.apache.cassandra.internal:type=MemtablePostFlusher: 
+  ActiveCount:
+  CompletedTasks: counter
+  PendingTasks:
+  CurrentlyBlockedTasks:
+  TotalBlockedTasks: counter
+org.apache.cassandra.internal:type=MigrationStage: 
+  ActiveCount:
+  CompletedTasks: counter
+  PendingTasks:
+  CurrentlyBlockedTasks:
+  TotalBlockedTasks: counter
+org.apache.cassandra.internal:type=MiscStage: 
+  ActiveCount:
+  CompletedTasks: counter
+  PendingTasks:
+  CurrentlyBlockedTasks:
+  TotalBlockedTasks: counter
+org.apache.cassandra.internal:type=PendingRangeCalculator: 
+  ActiveCount:
+  CompletedTasks: counter
+  PendingTasks:
+  CurrentlyBlockedTasks:
+  TotalBlockedTasks: counter
+org.apache.cassandra.internal:type=StreamStage: 
+  ActiveCount:
+  CompletedTasks: counter
+  PendingTasks:
+  CurrentlyBlockedTasks:
+  TotalBlockedTasks: counter
+org.apache.cassandra.request:type=MutationStage: 
+  ActiveCount:
+  CompletedTasks: counter
+  PendingTasks:
+  CurrentlyBlockedTasks:
+  TotalBlockedTasks: counter
+org.apache.cassandra.request:type=ReadRepairStage: 
+  ActiveCount:
+  CompletedTasks: counter
+  PendingTasks:
+  CurrentlyBlockedTasks:
+  TotalBlockedTasks: counter
+org.apache.cassandra.request:type=ReadStage: 
+  ActiveCount:
+  CompletedTasks: counter
+  PendingTasks:
+  CurrentlyBlockedTasks:
+  TotalBlockedTasks: counter
+org.apache.cassandra.request:type=ReplicateOnWriteStage: 
+  ActiveCount:
+  CompletedTasks: counter
+  PendingTasks:
+  CurrentlyBlockedTasks:
+  TotalBlockedTasks: counter
+org.apache.cassandra.request:type=RequestResponseStage: 
+  ActiveCount:
+  CompletedTasks: counter
+  PendingTasks:
+  CurrentlyBlockedTasks:
+  TotalBlockedTasks: counter
+org.apache.cassandra.net:type=MessagingService:
+  RecentTotalTimouts:
+  TotalTimeouts: counter
+org.apache.cassandra.metrics:type=ClientRequestMetrics,name=ReadTimeouts:
+  Count: counter
+org.apache.cassandra.metrics:type=ClientRequestMetrics,name=ReadUnavailables:
+  Count: counter
+org.apache.cassandra.metrics:type=ClientRequestMetrics,name=WriteTimeouts:
+  Count: counter
+org.apache.cassandra.metrics:type=ClientRequestMetrics,name=WriteUnavailables:
+  Count: counter


### PR DESCRIPTION
Some additional metrics for 1.2.x clusters. Tested with 1.2.5
