### PR TITLE
Added some additional validation so that any characters within a bean

### DIFF
--- a/lib/librato/metrics/taps/jmx.rb
+++ b/lib/librato/metrics/taps/jmx.rb
@@ -132,7 +132,7 @@ module Librato
           end
 
           def metric_name(bean_name, attr_name)
-            "#{bean_name.gsub('=', ':').gsub(/[, ]/, '_')}::#{attr_name}"
+            "#{bean_name.gsub('=', ':').gsub(/[, ]/, '_').gsub(/[^A-Za-z0-9\.:\-_]/, '_')}::#{attr_name}"
           end
         end
       end


### PR DESCRIPTION
name that doesn't conform to the librato api gets converted to an
underscore before being sent over to librato.  This should prevent
the API from throwing 400's for wonky bean names.  Looking at you
"kafka.server"!
