### PR TITLE
Added --interval-file option to specify different publish intervals for multiple data files

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ metrics_5min.yaml: 300
 metrics_1h.yaml: 3600
 ```
 
-The interval file must be specified using the `--interval-file <interval-file-path>` option.
+The interval file must be specified using the `--interval-file <interval-file-path>` option. A sample interval file is contained in the examples folder.
 
 ## Contributing to librato-metrics-taps
  

--- a/README.md
+++ b/README.md
@@ -142,6 +142,26 @@ librato-metrics-tap-jmxbeans --email "$EMAIL" --token "$TOKEN" \
     --measure-time "$MEASURE_TIME"
 ```
 
+### Daemon Mode
+
+#### Single Interval
+
+In order to poll and publish to librato every N seconds, specify `--interval <poll-interval>` option.
+
+#### Multiple Intervals
+
+In order to publish multiple YAML bean definition files in different intervals,
+you must supply an interval file, specifying a map from YAML data files to the
+period each file's metrics must be collected and published to librato. For example:
+
+```
+metrics_1min.yaml: 60
+metrics_5min.yaml: 300
+metrics_1h.yaml: 3600
+```
+
+The interval file must be specified using the `--interval-file <interval-file-path>` option.
+
 ## Contributing to librato-metrics-taps
  
 * Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet

--- a/bin/librato-metrics-tap-jmxbeans
+++ b/bin/librato-metrics-tap-jmxbeans
@@ -42,6 +42,63 @@ def publish_beans(publisher, beans, opts)
   return r
 end
 
+def load_yaml(filename)
+  begin
+    yaml_file= File.open(filename, "r")
+  rescue => err
+    puts "Failed to open yaml file #{filename}: #{err.message}"
+    exit 1
+  end
+
+  begin
+    yaml = YAML::load(yaml_file)
+  rescue => err
+    puts "Failed to parse yaml #{filename}: #{err.message}"
+    exit 1
+  end
+  yaml_file.close
+  return yaml
+end
+
+def publish_loop(opts, publisher, interval, beans)
+  # If --interval or --interval-file has been specified,
+  # broadcast every interval seconds. We wait for
+  # interval seconds each time to ensure we broadcast
+  # on the interval
+  #
+  # We use a random stagger to ensure that we are measuring and
+  # publishing our metrics at a random point within the period. This
+  # ensures that multiple entities are not measuring and reporting
+  # at the same exact points in time.
+
+  stagger = rand(interval)
+  begin
+    t = Time.now.tv_sec
+
+    # Floor the time to the current interval
+    t2 = (t / interval) * interval
+
+    # Offset by the stagger
+    t2 += stagger
+
+    # If our stagger is < interval/2, it is possible that we
+    # went back in time. In that case, simply skip another interval
+    #
+    if t2 <= t
+      t2 += interval
+    end
+
+    sleep (t2 - t)
+    t = Time.now
+
+    # We report our measure time as the nearest interval
+    tsecs = ((t.tv_sec + (interval / 2)) / interval) * interval
+
+    publish_beans(publisher, beans, opts.merge(:measure_time => tsecs))
+  end while true
+end
+
+
 opts = Trollop::options do
   version "Version: #{Taps::version}"
   banner <<EOS
@@ -67,6 +124,7 @@ EOS
   opt :metrics_url, "Metrics URL", :short => "-r", :default => 'https://metrics-api.librato.com'
 
   opt :interval, "Run as a daemon and poll every N seconds", :short => "-i", :type => :int
+  opt :interval_file, "YAML file specifying different intervals for multiple data files (daemon mode)", :type => :string
 
   opt :ignore_missing, "Ignore missing beans/attributes", :short => "-g"
 
@@ -118,89 +176,42 @@ end
 # Load full definition
 #
 if opts[:data_file_full]
-  filename = opts[:data_file_full]
-  begin
-    beanf = File.open(filename, "r")
-  rescue => err
-    puts "Failed to open bean file #{filename}: #{err.message}"
-    exit 1
-  end
-
-  begin
-    beans = YAML::load(beanf)
-  rescue => err
-    puts "Failed to parse #{filename}: #{err.message}"
-    exit 1
-  end
-  beanf.close
+  beans = load_yaml(opts[:data_file_full])
 elsif opts[:bean_name] && opts[:data_file_attributes]
-  # Load attributes from file
-  #
-  filename = opts[:data_file_attributes]
-  begin
-    beanf = File.open(filename, "r")
-  rescue => err
-    puts "Failed to open attributes file #{filename}: #{err.message}"
-    exit 1
-  end
-
-  begin
-    attrs = YAML::load(beanf)
-  rescue => err
-    puts "Failed to parse #{filename}: #{err.message}"
-    exit 1
-  end
-  beanf.close
+  attrs = load_yaml(opts[:data_file_attributes])
 
   beans = {}
   beannames = get_beans(opts[:bean_name])
   beannames.each do |name|
     beans[name] = attrs
   end
+elsif opts[:interval_file]
+  intervals = load_yaml(opts[:interval_file])
 else
-  err "Must specify --data-file-full or --data-file-attributes"
+  err "Must specify --data-file-full or --data-file-attributes or --interval-file"
 end
 
-unless opts[:interval]
+unless opts[:interval] or opts[:interval_file]
   r = publish_beans(publisher, beans, opts)
   exit(r ? 0 : 1)
 end
 
-# If --interval has been specified, broadcast every interval
-# seconds. We wait for interval seconds each time to ensure we
-# broadcast on the interval
-#
-# We use a random stagger to ensure that we are measuring and
-# publishing our metrics at a random point within the period. This
-# ensures that multiple entities are not measuring and reporting
-# at the same exact points in time.
-
-interval = opts[:interval]
-stagger = rand(interval)
-begin
-  t = Time.now.tv_sec
-
-  # Floor the time to the current interval
-  t2 = (t / interval) * interval
-
-  # Offset by the stagger
-  t2 += stagger
-
-  # If our stagger is < interval/2, it is possible that we
-  # went back in time. In that case, simply skip another interval
-  #
-  if t2 <= t
-    t2 += interval
+if opts[:interval]
+  #single interval, single datafile
+  interval = opts[:interval]
+  publish_loop(opts, publisher, interval, beans)
+elsif opts[:interval_file]
+  #multiple intervals, multiple datafiles
+  base_dir = File.dirname(opts[:interval_file])
+  workers = []
+  intervals.each do |data_file, interval|
+    data_file_path = "#{base_dir}/#{data_file}"
+    p "Starting publisher for data file #{data_file_path} with #{interval}s interval."
+    jmx_beans = load_yaml(data_file_path)
+    workers << Thread.new{publish_loop(opts, publisher, interval.to_i, jmx_beans)}
   end
-
-  sleep (t2 - t)
-  t = Time.now
-
-  # We report our measure time as the nearest interval
-  tsecs = ((t.tv_sec + (interval / 2)) / interval) * interval
-
-  publish_beans(publisher, beans, opts.merge(:measure_time => tsecs))
-end while true
+  workers.map(&:join)
+end
 
 exit 1
 

--- a/examples/interval-file.yaml
+++ b/examples/interval-file.yaml
@@ -1,0 +1,3 @@
+cassandra/cfstats-2_0_9.yaml: 300 #5 minutes resolution
+cassandra/tpstats-2_0_9.yaml: 120 #2 minutes resolution
+java-lang.yaml: 60 #1 minute resolution


### PR DESCRIPTION
We have a use case where we need to publish different metrics to librato in different resolution intervals. 
One way to do this is to have multiple librato-metrics-taps instances with different --data-file-full and --interval options. However, jruby is quite heavyweight and I don't want to have multiple JVM instances running to publish metrics in different intervals.

I tried adapting the YAML data file format to support different publishing intervals, but I couldn't find a way to do it without breaking backward compatibility. The solution was to create a new type of configuration file (interval file), that specifies a publishing interval for each data file. I also added documentation and example interval files, so the new feature could be useful for users with similar use cases without breaking current use cases.
